### PR TITLE
Remove CPU resource limit from processor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Lint
         run: flake8
       - name: Test
-        run: pytest --cov-report=term --cov-report=html --cov
+        run: pytest --cov-report=term --cov-report=xml --cov
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v2

--- a/deploy/chart/templates/events-enclave-processor-deployment.yaml
+++ b/deploy/chart/templates/events-enclave-processor-deployment.yaml
@@ -32,7 +32,4 @@ spec:
               value: {{ .jsonOutputS3Bucket }}
             - name: JSON_OUTPUT_S3_KEY
               value: {{ .jsonOutputS3Key }}
-          resources:
-                limits:
-                  cpu: "250m"
 {{- end }}


### PR DESCRIPTION
I realized that setting a limit implies a corresponding request if it's not already defined, which was unintentional. Instead of adding an explicit request value, for now I'm just going to remove the config altogether since these processors should be I/O bound for the most part anyways. We can revisit in the future as needed.