### PR TITLE
Upgrade metabase version

### DIFF
--- a/dashboard/compose.yaml
+++ b/dashboard/compose.yaml
@@ -1,6 +1,6 @@
 services:
   metabase:
-    image: metabase/metabase:v0.46.6
+    image: metabase/metabase:v0.46.6.1
     networks:
       - dashboard
     ports:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -21,7 +21,7 @@ eventsEnclaveProcessor:
 dashboard:
   domain: metrics.raiselearning.org
   replicas: 2
-  metabaseVersion: v0.46.6
+  metabaseVersion: v0.46.6.1
   pgServer:
   pgUsername:
   pgPassword:


### PR DESCRIPTION
Per this note, the upgrade is urgent / related to security fixes: https://github.com/metabase/metabase/releases/tag/v0.46.6.1